### PR TITLE
Rank-one Update Fix

### DIFF
--- a/gpyreg/gaussian_process.py
+++ b/gpyreg/gaussian_process.py
@@ -715,8 +715,8 @@ class GP:
                         full_update_s = True #  Mark this posterior for full update
                         full_updates.append(s)
                         warnings.warn(
-                            "Rank-one update of Cholesky factor" +\
-                            f"failed for posterior {s}. Reverting to full update.",
+                            "Rank-one update of Cholesky factor " +\
+                            f"unstable for posterior {s}. Reverting to full update.",
                             stacklevel=2
                         )
                     else:  # Otherwise continue with rank-1 update:


### PR DESCRIPTION
Fixes a bug in the rank-one update of the posterior Cholesky factor, where negative values in `sqrt()` would rarely appear due to numerical instability, and cause PyVBMC to freeze in `cmaes.fmin().`

Now, if a non-positive value appears in that `sqrt()` argument, we warn the user, revert to a full update for that posterior, and re-compute the Cholesky factor from scratch.