### PR TITLE
Indexing

### DIFF
--- a/gpyreg/covariance_functions.py
+++ b/gpyreg/covariance_functions.py
@@ -38,7 +38,7 @@ class AbstractKernel(ABC):
             K : ndarray
                 The covariance matrix which is by default of shape ``(N, N)``. If
                 ``compute_diag = True`` the shape is ``(N,)``.
-            dK : ndarray, shape (cov_N, N, N), optional
+            dK : ndarray, shape (N, N, cov_N), optional
                 The gradient of the covariance matrix with respect to the
                 hyperparameters.
 
@@ -171,7 +171,7 @@ class SquaredExponential(AbstractKernel):
                 )
             # Gradient of cov output scale.
             dK[D, :, :] = 2 * K
-            return K, dK
+            return K, dK.transpose(1, 2, 0)
 
         return K
 
@@ -265,7 +265,7 @@ class Matern(AbstractKernel):
                     dK[i, :, :] = sf2 * (self.df(tmp) * np.exp(-tmp)) * Ki
             # Gradient of cov output scale
             dK[D, :, :] = 2 * K
-            return K, dK
+            return K, dK.transpose(1, 2, 0)
 
         return K
 
@@ -338,7 +338,7 @@ class RationalQuadraticARD(AbstractKernel):
             # Gradient respect of alpha.
             dK[D+1, :, :] = K * (0.5 * tmp/M - alpha * np.log(M))
 
-            return K, dK
+            return K, dK.transpose(1, 2, 0)
 
         return K
 

--- a/gpyreg/gaussian_process.py
+++ b/gpyreg/gaussian_process.py
@@ -1488,7 +1488,7 @@ class GP:
         mu : ndarray, shape (M, sample_N)
             Posterior mean at the requested points for each hyperparameter
             sample.
-        cov : ndarray, shape (sample_N, M, M)
+        cov : ndarray, shape (M, M, sample_N)
             Covariance matrix for each hyperparameter sample.
         """
 
@@ -1561,7 +1561,7 @@ class GP:
                 )
                 cov[s, :, :] += np.dot(np.eye(N_star), sn2_star) * sn2_mult
 
-        return mu, cov
+        return mu, cov.transpose(1, 2, 0)
 
     def predict(
         self,
@@ -2390,7 +2390,7 @@ class GP:
 
                 # Gradient of covariance hyperparameters.
                 for i in range(0, cov_N):
-                    dnlZ[i] = np.sum(np.sum(Q * dK[i, :, :])) / 2
+                    dnlZ[i] = np.sum(np.sum(Q * dK[:, :, i])) / 2
 
                 # Gradient of GP likelihood
                 if np.isscalar(sn2):

--- a/tests/test_covariance_functions.py
+++ b/tests/test_covariance_functions.py
@@ -148,7 +148,7 @@ def _test_kernel_gradient_(kernel_fun: AbstractKernel, hyp, X:np.ndarray, X_star
     K, dK = kernel_fun.compute(hyp, X, X_star, compute_grad=True)
 
     hyp_new = hyp.copy()
-    finite_diff = np.zeros((len(hyp), K.shape[0], K.shape[1]))
+    finite_diff = np.zeros((K.shape[0], K.shape[1], len(hyp)))
 
     for idx, h_p in enumerate(hyp.squeeze()):
         hyp_new[idx] = h_p + 2.0 * h
@@ -166,8 +166,8 @@ def _test_kernel_gradient_(kernel_fun: AbstractKernel, hyp, X:np.ndarray, X_star
         hyp_new[idx] = h_p - 2*h
         f_neg_2h = kernel_fun.compute(hyp_new, X, X_star)
 
-        finite_diff[idx, :, :] = -f_2h + 8.0 * f_h - 8.0 * f_neg_h + f_neg_2h
-        finite_diff[idx, :, :] = finite_diff[idx, :, :] / (12 * h)
+        finite_diff[:, :, idx] = -f_2h + 8.0 * f_h - 8.0 * f_neg_h + f_neg_2h
+        finite_diff[:, :, idx] = finite_diff[:, :, idx] / (12 * h)
     
     assert np.all(np.abs(finite_diff - dK) <= eps)
 

--- a/tests/test_gaussian_process.py
+++ b/tests/test_gaussian_process.py
@@ -544,7 +544,7 @@ def test_quadrature_without_noise():
 
     pdf_tmp = np.reshape(scipy.stats.norm.pdf(x_star, scale=0.1), (-1, 1))
     tmp = np.dot(pdf_tmp, pdf_tmp.T)
-    F_var_predict = np.sum(np.sum(f_cov[0, :, :] * tmp)) * (20 / mu_N) ** 2
+    F_var_predict = np.sum(np.sum(f_cov[:, :, 0] * tmp)) * (20 / mu_N) ** 2
 
     F_bayes, F_var_bayes = gp.quad(0, 0.1, compute_var=True)
 
@@ -608,7 +608,7 @@ def test_quadrature_with_noise():
 
     pdf_tmp = np.reshape(scipy.stats.norm.pdf(x_star, scale=0.1), (-1, 1))
     tmp = np.dot(pdf_tmp, pdf_tmp.T)
-    F_predict_var = np.sum(np.sum(f_cov[0, :, :] * tmp)) * (30 / mu_N) ** 2
+    F_predict_var = np.sum(np.sum(f_cov[:, :, 0] * tmp)) * (30 / mu_N) ** 2
 
     F_bayes, F_bayes_var = gp.quad(0, 0.1, compute_var=True)
 


### PR DESCRIPTION
Changes indexing of large 3+ dimensional arrays to respect Python memory order. See [matching PR](https://github.com/lacerbi/pyvbmc/pull/87) in `PyVBMC`.