### PR TITLE
Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
       - uses: actions/setup-python@v4
         name: Install Python
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: build
+
+on:
+  push:
+    branches:
+      - main
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: "3.9"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install -U build setuptools_scm
+          python -m build .
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+# From https://github.com/eeholmes/readthedoc-test/blob/main/.github/workflows/docs_pages.yml
+name: docs
+
+# execute this workflow automatically when a we push to main
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+
+  build_docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v3
+        with:
+          path: main
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v3
+        with:
+          path: gh-pages
+          ref: gh-pages
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          cd ./main
+          python -m pip install .[dev]
+      - name: Make the Sphinx docs
+        run: |
+          cd ./main/docsrc
+          make clean
+          make github
+      - name: Commit changes to docs
+        run: |
+          cd ./gh-pages
+          cp -R ../main/docs/* ./
+          git config --local user.email ""
+          git config --local user.name "github-actions"
+          git add -A
+          if ! git diff-index --quiet HEAD; then
+            git commit -m "auto: Rebuild docs."
+            git  push
+          else
+            echo No commit made because the docs have not changed.
+          fi

--- a/.github/workflows/merge-tests.yml
+++ b/.github/workflows/merge-tests.yml
@@ -58,7 +58,6 @@ jobs:
       - name: Checkout GPyReg
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
           path: gpyreg
 
       - name: Setup Python

--- a/.github/workflows/merge-tests.yml
+++ b/.github/workflows/merge-tests.yml
@@ -1,0 +1,77 @@
+# From github.com/dfm/tinygp
+name: merge-tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run_job: ${{ steps.check_files.outputs.run_job }}
+    steps:
+      - name: Checkout GPyReg
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: gpyreg
+
+      - name: Check for modified files
+        id: check_files
+        run: |
+          cd ./gpyreg
+          echo "=============== list modified files ==============="
+          git diff --name-only origin/main
+
+          echo "========== check paths of modified files =========="
+          git diff --name-only origin/main > files.txt
+          echo "run_job=false" >> $GITHUB_OUTPUT
+          changes=false
+          while IFS= read -r file
+          do
+            echo $file
+            if [[ $file != gpyreg/* ]]; then
+              :
+            else
+              echo "Change in source directory found, running tests."
+              echo "run_job=true" >> $GITHUB_OUTPUT
+              changes=true
+              break
+            fi
+          done < files.txt
+          if [ "$changes" = false ]; then
+            echo "No changes to source directory found, skipping tests."
+          fi
+
+  tests:
+    needs: check_changes
+    if: needs.check_changes.outputs.run_job == 'true'
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.9", "3.10", "3.11"]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout GPyReg
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: gpyreg
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install GPyReg
+        run: |
+          cd ./gpyreg
+          python -m pip install -e .
+
+      - name: Run tests
+        run: |
+          cd ./gpyreg
+          python -m pytest --reruns=5 -x -vv

--- a/.github/workflows/merge-tests.yml
+++ b/.github/workflows/merge-tests.yml
@@ -32,10 +32,10 @@ jobs:
           while IFS= read -r file
           do
             echo $file
-            if [[ $file != gpyreg/* ]]; then
+            if [[ ($file != gpyreg/*) && ($file != pyproject.toml) && ($file != setup.py) ]]; then
               :
             else
-              echo "Change in source directory found, running tests."
+              echo "Change in source files found, running tests."
               echo "run_job=true" >> $GITHUB_OUTPUT
               changes=true
               break

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    uses: Bobby-Huggins/gpyreg-test/.github/workflows/build.yml@main
+    uses: acerbilab/gpyreg/.github/workflows/build.yml@main
   upload_to_pypi:
     needs: [build]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: publish-release
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: Bobby-Huggins/gpyreg-test/.github/workflows/build.yml@main
+  upload_to_pypi:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download built package
+        uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.6.4
+        with:
+          password: ${{ secrets.pypi_password }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,8 @@ name: tests
 on:
   workflow_dispatch:
   schedule:
-    - cron:  '23 00 * * 0'
+    # Run on the 13th and 28th of each month, at 00:23 UTC:
+    - cron:  '23 00 13,28 * *'
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,6 @@
 name: tests
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
   schedule:
     - cron:  '23 00 * * 0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+# From github.com/dfm/tinygp
+name: tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+  schedule:
+    - cron:  '23 00 * * 0'
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.9", "3.10", "3.11"]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install GPyReg
+        run: |
+          python -m pip install -e .
+      - name: Run tests
+        run: python -m pytest --reruns=5 -x -vv

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # GPyReg
+![Version](https://img.shields.io/badge/dynamic/json?label=python&query=info.requires_python&url=https%3A%2F%2Fpypi.org%2Fpypi%2Fpyvbmc%2Fjson)
+[![Conda](https://img.shields.io/conda/v/conda-forge/gpyreg)](https://anaconda.org/conda-forge/gpyreg)
+[![PyPI](https://img.shields.io/pypi/v/gpyreg)](https://pypi.org/project/gpyreg/)
+<br />
+[![Discussion](https://img.shields.io/badge/-discussion-blue?logo=github)](https://github.com/orgs/acerbilab/discussions)
+[![build](https://github.com/acerbilab/gpyreg/actions/workflows/build.yml/badge.svg)](https://github.com/acerbilab/gpyreg/actions/workflows/build.yml)
+[![tests](https://github.com/acerbilab/gpyreg/actions/workflows/tests.yml/badge.svg)](https://github.com/acerbilab/gpyreg/actions/workflows/tests.yml)
+[![docs](https://github.com/acerbilab/gpyreg/actions/workflows/docs.yml/badge.svg)](https://github.com/acerbilab/gpyreg/actions/workflows/docs.yml)
 ### What is it?
 GPyReg is a lightweight package for Gaussian process regression in Python. It was developed for use with [PyVBMC](https://github.com/acerbilab/pyvbmc) (a Python package for efficient black-box Bayesian inference) but is usable as a standalone package.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # GPyReg
-![Version](https://img.shields.io/badge/dynamic/json?label=python&query=info.requires_python&url=https%3A%2F%2Fpypi.org%2Fpypi%2Fpyvbmc%2Fjson)
+![Version](https://img.shields.io/badge/dynamic/json?label=python&query=info.requires_python&url=https%3A%2F%2Fpypi.org%2Fpypi%2Fgpyreg%2Fjson)
 [![Conda](https://img.shields.io/conda/v/conda-forge/gpyreg)](https://anaconda.org/conda-forge/gpyreg)
 [![PyPI](https://img.shields.io/pypi/v/gpyreg)](https://pypi.org/project/gpyreg/)
 <br />
 [![Discussion](https://img.shields.io/badge/-discussion-blue?logo=github)](https://github.com/orgs/acerbilab/discussions)
-[![build](https://github.com/acerbilab/gpyreg/actions/workflows/build.yml/badge.svg)](https://github.com/acerbilab/gpyreg/actions/workflows/build.yml)
-[![tests](https://github.com/acerbilab/gpyreg/actions/workflows/tests.yml/badge.svg)](https://github.com/acerbilab/gpyreg/actions/workflows/tests.yml)
-[![docs](https://github.com/acerbilab/gpyreg/actions/workflows/docs.yml/badge.svg)](https://github.com/acerbilab/gpyreg/actions/workflows/docs.yml)
+[![tests](https://img.shields.io/github/actions/workflow/status/acerbilab/gpyreg/tests.yml?branch=main&label=tests)](https://github.com/acerbilab/gpyreg/actions/workflows/tests.yml)
+[![docs](https://img.shields.io/github/actions/workflow/status/acerbilab/gpyreg/build.yml?branch=main&label=docs)](https://github.com/acerbilab/gpyreg/actions/workflows/docs.yml)
+[![build](https://img.shields.io/github/actions/workflow/status/acerbilab/gpyreg/docs.yml?branch=main&label=build)](https://github.com/acerbilab/gpyreg/actions/workflows/build.yml)
 ### What is it?
 GPyReg is a lightweight package for Gaussian process regression in Python. It was developed for use with [PyVBMC](https://github.com/acerbilab/pyvbmc) (a Python package for efficient black-box Bayesian inference) but is usable as a standalone package.
 

--- a/docsrc/source/conf.py
+++ b/docsrc/source/conf.py
@@ -14,6 +14,7 @@ import inspect
 #
 import os
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath("../.."))
 
@@ -70,11 +71,9 @@ def linkcode_resolve(domain, info):
         obj = getattr(obj, part)
 
     # unwrap to get rid of decorators.
-    filename = inspect.getsourcefile(inspect.unwrap(obj))
-
-    # to get rid of the local path, quiet hacky, but works
-    filename = filename[filename.index("gpyreg/") + 7 :]
-    return "https://github.com/acerbilab/gpyreg/tree/main/%s" % filename
+    file = Path(inspect.getsourcefile(inspect.unwrap(obj)))
+    filename = file.name
+    return "https://github.com/acerbilab/gpyreg/tree/main/gpyreg/%s" % filename
 
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "sphinx >= 4.3.2",
     "sphinx-book-theme>=0.2.0",
     "build >= 0.9.0",
+    "numpydoc >= 1.2.1",
 ]
 
 [build-system]


### PR DESCRIPTION
1. Adds the following GitHub workflows:
    1. merge-tests
        - runs when a PR is opened (on the PR'd branch)
        - runs all `pytest` tests on Linux/Windows/MacOS with Python versions 3.9/3.10/3.11
        - only runs tests if files have changed in the gpyreg/pyvbmc source directory, or `pyproject.toml` (e.g., not when only documentation has changed)
   2. tests
       - runs twice a month (13th and 28th) on the main branch
       - runs all `pytest` tests on Linux/Windows/MacOS with Python versions 3.9/3.10/3.11
   3. docs
       - runs on merge to the main branch
       - rebuilds documentation and uploads to gh-pages branch
   4. build
       - runs on merge to main branch (or when called by release).
       - builds the package
   5. release
       - runs when a new GitHub release is created.
       - builds the package and uploads the new version to PyPI.
2. Add some badges to the README.md
   1. available versions, links to PyPI, Conda and Discussions page, status of tests, build, and docs workflows