### PR TITLE
chore: fix `release` workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
           password: ${{ secrets.pypi_password }}
-          repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Fixes the `release` workflow to use the official PyPI repository instead of the PyPI test repository.