### PR TITLE
Fix behaviour of `s2=None`.

### DIFF
--- a/gpyreg/gaussian_process.py
+++ b/gpyreg/gaussian_process.py
@@ -2554,7 +2554,7 @@ class GP:
         elif isinstance(s2, np.ndarray):
             s2 = s2.reshape(N, 1)
         elif s2 is None:
-            s2 = None  # noisyless case
+            s2 = None  # noiseless case
         else:
             raise TypeError(
                 "s2 type need to be \

--- a/gpyreg/gaussian_process.py
+++ b/gpyreg/gaussian_process.py
@@ -2554,7 +2554,7 @@ class GP:
         elif isinstance(s2, np.ndarray):
             s2 = s2.reshape(N, 1)
         elif s2 is None:
-            s2 = np.zeros((N, 1))
+            s2 = None  # noisyless case
         else:
             raise TypeError(
                 "s2 type need to be \

--- a/gpyreg/noise_functions.py
+++ b/gpyreg/noise_functions.py
@@ -255,6 +255,8 @@ class GaussianNoise:
                 dsn2[:, i] = 2 * sn2
             i += 1
 
+        if s2 is None:
+            s2 = 0
         if self.parameters[1] == 1:
             sn2 += s2
         elif self.parameters[1] == 2:

--- a/gpyreg/testing/test_gaussian_process.py
+++ b/gpyreg/testing/test_gaussian_process.py
@@ -832,7 +832,7 @@ def test_fitting_options():
 
 
 def test_fitting():
-    N = 1000
+    N = 500
     D = 1
     X = np.reshape(np.linspace(-10, 10, N), (-1, 1))
 
@@ -1151,11 +1151,7 @@ def test_convert_shapes():
     assert X.shape == (N, D) and y.shape == (N, 1) and s2.shape == (N, 1)
     s2 = None
     X, y, s2 = gp._convert_shapes(X, y, s2)
-    assert (
-        X.shape == (N, D)
-        and y.shape == (N, 1)
-        and np.allclose(s2, np.zeros((N, 1)))
-    )
+    assert X.shape == (N, D) and y.shape == (N, 1) and s2 is None
     s2 = 1
     X, y, s2 = gp._convert_shapes(X, y, s2)
     assert (

--- a/gpyreg/testing/test_gaussian_process_isotropic.py
+++ b/gpyreg/testing/test_gaussian_process_isotropic.py
@@ -834,7 +834,7 @@ def test_fitting_options():
 
 
 def test_fitting():
-    N = 1000
+    N = 500
     D = 1
     X = np.reshape(np.linspace(-10, 10, N), (-1, 1))
 


### PR DESCRIPTION
Keep `s2=None` to indicate the noiseless case.